### PR TITLE
Adding validation to config settings to clarify correct values

### DIFF
--- a/WebApp-OpenIDConnect-DotNet/App_Start/AuthConfig.cs
+++ b/WebApp-OpenIDConnect-DotNet/App_Start/AuthConfig.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.IdentityModel.Protocols;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Configuration;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+
+namespace WebApp_OpenIDConnect_DotNet
+{
+    public class AuthConfig
+    {
+        private string clientId;
+        private string aadInstance;
+        private string tenant;
+        private string appBaseUri;
+
+        public static class SettingName
+        {
+            public const string ClientId = "ida:ClientId";
+            public const string AadInstance = "ida:AADInstance";
+            public const string Tenant = "ida:Tenant";
+            public const string AppBaseUri = "ida:AppBaseUri";
+        }
+
+        private AuthConfig(NameValueCollection appSettings)
+        {
+            if (appSettings == null)
+            {
+                throw new ArgumentNullException($"{appSettings}", "ConfigurationManager.AppSettings should be passed to AuthConfig");
+            }
+
+            clientId = appSettings[SettingName.ClientId];
+            aadInstance = appSettings[SettingName.AadInstance];
+            tenant = appSettings[SettingName.Tenant];
+            appBaseUri = appSettings[SettingName.AppBaseUri];
+
+            GuardAgainstBadAppSettingValues();
+        }
+
+        public static AuthSettings GetSettings(NameValueCollection appSettings)
+        {
+            var config = new AuthConfig(appSettings);
+            return new AuthSettings(config.clientId, config.aadInstance, config.tenant, config.appBaseUri);
+        }
+
+        private void GuardAgainstBadAppSettingValues()
+        {
+            var messages = new StringBuilder();
+
+            CheckClientId(messages);
+            CheckAadInstance(messages);
+            CheckTenant(messages);
+            CheckBaseUri(messages);
+
+            if (messages.Length > 0)
+            {
+                throw new InvalidOperationException(messages.ToString());
+            }
+        }
+
+        private void CheckClientId(StringBuilder messages)
+        {
+            CheckForNullOrEmptyValue(clientId, SettingName.ClientId, messages);
+
+            Guid clientIdValue;
+            if (!Guid.TryParse(clientId, out clientIdValue))
+            {
+                messages.AppendLine($"{SettingName.ClientId} value is not a Guid. The value should be the Guid Id of the Application created in the Azure AD tenant.");
+            }
+        }
+
+        private void CheckAadInstance(StringBuilder messages)
+        {
+            CheckForNullOrEmptyValue(aadInstance, SettingName.AadInstance, messages);
+            CheckUri(aadInstance, SettingName.AadInstance, messages);
+        }
+        private void CheckTenant(StringBuilder messages)
+        {
+            CheckForNullOrEmptyValue(tenant, SettingName.Tenant, messages);
+
+            if (!Regex.IsMatch(tenant, "^[^/@]*\\.onmicrosoft\\.com(/.*)?$"))
+            {
+                messages.AppendLine($"{SettingName.Tenant} must have the name of the tenant followed by .onmicrosoft.com, e.g. contoso.onmicrosoft.com");
+            }
+        }
+
+        private void CheckBaseUri(StringBuilder messages)
+        {
+            CheckForNullOrEmptyValue(appBaseUri, SettingName.AppBaseUri, messages);
+            CheckUri(appBaseUri, SettingName.AppBaseUri, messages);
+        }
+
+        private void CheckForNullOrEmptyValue(string value, string settingName, StringBuilder messages)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                messages.AppendLine($"{settingName} value is empty or null.");
+            }
+        }
+        private void CheckUri(string value, string settingName, StringBuilder messages)
+        {
+            Uri uri;
+            if (!Uri.TryCreate(value, UriKind.Absolute, out uri))
+            {
+                messages.AppendLine($"{settingName} value '{value}' is not a valid Uri. A valid example for {settingName} value would be 'https://localhost/'");
+            }
+        }
+    }
+
+    public struct AuthSettings
+    {
+        public string ClientId { get; }
+        public string AadInstance { get; }
+        public string Tenant { get; }
+        public string RedirectUri { get; }
+        public string PostLogoutRedirectUri { get; }
+        public string Authority { get; }
+
+        public AuthSettings(string clientId, string aadInstance, string tenant, string baseUri)
+        {
+            ClientId = clientId;
+            AadInstance = aadInstance;
+            Tenant = tenant;
+            RedirectUri = baseUri;
+            PostLogoutRedirectUri = baseUri;
+            Authority = GetAuthority(aadInstance, tenant);
+        }
+
+        private static string GetAuthority(string aadInstance, string tenant)
+        {
+            var uri = new UriBuilder(aadInstance);
+            uri.Path = tenant;
+
+            return uri.ToString();
+        }
+    }
+}

--- a/WebApp-OpenIDConnect-DotNet/App_Start/Startup.Auth.cs
+++ b/WebApp-OpenIDConnect-DotNet/App_Start/Startup.Auth.cs
@@ -14,51 +14,34 @@
 //    limitations under the License.
 //----------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-
 // The following using statements were added for this sample.
 using Owin;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OpenIdConnect;
 using System.Configuration;
-using System.Globalization;
+
 using System.Threading.Tasks;
 
 namespace WebApp_OpenIDConnect_DotNet
 {
     public partial class Startup
     {
-        //
-        // The Client ID is used by the application to uniquely identify itself to Azure AD.
-        // The Metadata Address is used by the application to retrieve the signing keys used by Azure AD.
-        // The AAD Instance is the instance of Azure, for example public Azure or Azure China.
-        // The Authority is the sign-in URL of the tenant.
-        // The Post Logout Redirect Uri is the URL where the user will be redirected after they sign out.
-        //
-        private static string clientId = ConfigurationManager.AppSettings["ida:ClientId"];
-        private static string aadInstance = ConfigurationManager.AppSettings["ida:AADInstance"];
-        private static string tenant = ConfigurationManager.AppSettings["ida:Tenant"];
-        private static string postLogoutRedirectUri = ConfigurationManager.AppSettings["ida:PostLogoutRedirectUri"];
-
-        string authority = String.Format(CultureInfo.InvariantCulture, aadInstance, tenant);
-
         public void ConfigureAuth(IAppBuilder app)
         {
-            app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
+            var settings = AuthConfig.GetSettings(ConfigurationManager.AppSettings);
 
+            app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
             app.UseCookieAuthentication(new CookieAuthenticationOptions());
 
             app.UseOpenIdConnectAuthentication(
                 new OpenIdConnectAuthenticationOptions
                 {
-                    ClientId = clientId,
-                    Authority = authority,
-                    PostLogoutRedirectUri = postLogoutRedirectUri,
-                    RedirectUri = postLogoutRedirectUri,
+                    ClientId = settings.ClientId,
+                    Authority = settings.Authority,
+                    PostLogoutRedirectUri = settings.PostLogoutRedirectUri,
+                    RedirectUri = settings.RedirectUri,
+
                     Notifications = new OpenIdConnectAuthenticationNotifications
                     {
                         AuthenticationFailed = context => 

--- a/WebApp-OpenIDConnect-DotNet/Web.config
+++ b/WebApp-OpenIDConnect-DotNet/Web.config
@@ -8,12 +8,13 @@
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
-    <add key="UnobtrusiveJavaScriptEnabled" value="true" />  
-    <add key="ida:ClientId" value="[Enter client ID as obtained from Azure Portal, e.g. 82692da5-a86f-44c9-9d53-2f88d52b478b]" />
-    <add key="ida:Tenant" value="[Enter tenant name, e.g. contoso.onmicrosoft.com]" />
-    <add key="ida:AADInstance" value="https://login.microsoftonline.com/{0}" />
-    <add key="ida:PostLogoutRedirectUri" value="https://localhost:44320/" />
+    <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     
+    <add key="ida:ClientId" value="00000000-0000-0000-0000-000000000000" /><!-- Enter client ID as obtained from Azure Portal, e.g. 82692da5-a86f-44c9-9d53-2f88d52b478b -->
+    <add key="ida:Tenant" value="[yourtenantname].onmicrosoft.com" /><!-- Enter tenant name, e.g. contoso.onmicrosoft.com -->
+    <add key="ida:AADInstance" value="https://login.microsoftonline.com/" />
+    <add key="ida:AppBaseUri" value="https://localhost:44320" />
+
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5" />

--- a/WebApp-OpenIDConnect-DotNet/WebApp-OpenIDConnect-DotNet.csproj
+++ b/WebApp-OpenIDConnect-DotNet/WebApp-OpenIDConnect-DotNet.csproj
@@ -142,6 +142,7 @@
     <Folder Include="Views\Error\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="App_Start\AuthConfig.cs" />
     <Compile Include="App_Start\BundleConfig.cs" />
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />


### PR DESCRIPTION
Validation is now in place for what's set in the app settings to give immediate feedback
to person using sample for themselves. 

Also removed "PostLogoutRedirectUri and used a base app uri instead to
remove confusion for what's the postlogout uri and the redirect uri. Now
they are both set to the same value. Found almost every time that the consumer of the sample was confused what they should set for the Uri. 